### PR TITLE
include Fossa Links now that scan has run successfully

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![CircleCI](https://circleci.com/gh/GrindrodBank/scrubfu.svg?style=svg)](https://circleci.com/gh/GrindrodBank/scrubfu)
+[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2FGrindrodBank%2Fscrubfu.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2FGrindrodBank%2Fscrubfu?ref=badge_shield)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=scrubfu&metric=alert_status)](https://sonarcloud.io/dashboard?id=scrubfu)
 
 # Scrubfu
@@ -181,3 +182,6 @@ All project documentation is currently available within the /doc folder.
 
 ---
 &copy; Copyright 2019, Grindrod Bank Limited, and distributed under the MIT License.
+
+## License
+[![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2FGrindrodBank%2Fscrubfu.svg?type=large)](https://app.fossa.io/projects/git%2Bgithub.com%2FGrindrodBank%2Fscrubfu?ref=badge_large)


### PR DESCRIPTION
There are 2 places to check for the Fossa Scan on README. 
1) the top at the badges level (see) but please check links go to correct places when reviewing
![image](https://user-images.githubusercontent.com/6588511/62917484-bc1bd800-bd9c-11e9-8e89-c8ce78258eef.png)

2) at the bottom of page (see) but please check links go to correct places when reviewing
![image](https://user-images.githubusercontent.com/6588511/62917512-da81d380-bd9c-11e9-86d8-ae15f48302f4.png)

