### PR TITLE
pin fossa-cli to v1.0.0 to work around a bug in their latest release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,8 @@ jobs:
       - run: apk --no-cache add --update curl bash git openssh
       # Install Fossa
       - run: |
-          curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | tac | tac | sudo bash
+          #curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | tac | tac | sudo bash
+          curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | sudo bash -s v1.0.0          
       # Install Maven
       - checkout
       - run: FOSSA_API_KEY=$FOSSA_API_KEY fossa init


### PR DESCRIPTION
- https://github.com/fossas/fossa-cli/issues/527
Their install script current latest (1.0.4) does not have a correctly
compiled application for all operating systems thus it does not work on
alpine