### PR TITLE
2635 update scrubfu to dotnet core 3 1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
           -Dsonar.cs.opencover.reportsPaths=../workspace/tests/Scrubfu.Tests/coverage.opencover.xml
   test:
     docker:
-      - image: mcr.microsoft.com/dotnet/core/sdk:2.2-alpine
+      - image: mcr.microsoft.com/dotnet/core/sdk:3.1-alpine
     working_directory: ~/build
     
     steps:
@@ -91,7 +91,7 @@ jobs:
           docker push grindrodbank/scrubfu:latest
   fossa-scan:
     docker:
-      - image: mcr.microsoft.com/dotnet/core/sdk:2.2-alpine
+      - image: mcr.microsoft.com/dotnet/core/sdk:3.1-alpine
     working_directory: ~/build
     steps:
       # Update, upgrade, then install su, curl, bash, git and openssh
@@ -111,7 +111,7 @@ jobs:
       - run: FOSSA_API_KEY=$FOSSA_API_KEY fossa test
   vulnerability-test:
     docker:
-      - image: mcr.microsoft.com/dotnet/core/sdk:2.2-alpine
+      - image: mcr.microsoft.com/dotnet/core/sdk:3.1-alpine
     working_directory: ~/build
     steps:
       # Update, upgrade, then install sudo, nodejs, npm, git and openssh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,6 @@ jobs:
           -Dsonar.projectBaseDir=$CI_PROJECT_DIR \
           -Dsonar.sourceEncoding=UTF-8 \
           -Dsonar.test.inclusions=tests/**/* \
-          -Dsonar.sources=. \
           -Dsonar.cs.opencover.reportsPaths=../workspace/tests/Scrubfu.Tests/coverage.opencover.xml
   test:
     docker:

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # **************************************************
 #
 
-FROM mcr.microsoft.com/dotnet/core/sdk:2.2-alpine AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1-alpine AS build
 WORKDIR /app/scrubfu
 
 # copy csproj and restore as distinct layers
@@ -21,7 +21,7 @@ WORKDIR /app/scrubfu/src/scrubfu
 RUN dotnet add package ILLink.Tasks -v 0.1.5-preview-1841731 -s https://dotnet.myget.org/F/dotnet-core/api/v3/index.json
 RUN dotnet publish -c Release -r linux-musl-x64 -o out /p:ShowLinkerSizeComparison=true 
 
-FROM mcr.microsoft.com/dotnet/core/runtime-deps:2.2-alpine AS runtime
+FROM mcr.microsoft.com/dotnet/core/runtime-deps:3.1-alpine AS runtime
 WORKDIR /app
 COPY --from=build /app/scrubfu/src/scrubfu/out/ ./
 ENTRYPOINT ["./scrubfu"]

--- a/README.md
+++ b/README.md
@@ -184,4 +184,5 @@ All project documentation is currently available within the /doc folder.
 &copy; Copyright 2019, Grindrod Bank Limited, and distributed under the MIT License.
 
 ## License
+
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2FGrindrodBank%2Fscrubfu.svg?type=large)](https://app.fossa.io/projects/git%2Bgithub.com%2FGrindrodBank%2Fscrubfu?ref=badge_large)

--- a/scrubfu.sln
+++ b/scrubfu.sln
@@ -28,6 +28,6 @@ Global
 		SolutionGuid = {5E22C3E8-FD63-454B-907B-96579E098A89}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
-		version = 0.1.0
+		version = 1.1
 	EndGlobalSection
 EndGlobal

--- a/src/scrubfu/Scrubfu.csproj
+++ b/src/scrubfu/Scrubfu.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>scrubfu</AssemblyName>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <PackageId>Scrubfu</PackageId>
     <Version>0.1.0</Version>
     <Authors>Darin Morris, Paul van Coller</Authors>
@@ -14,13 +14,12 @@
     <RepositoryType>Git</RepositoryType>
     <PackageProjectUrl>https://github.com/GrindrodBank/scrubfu</PackageProjectUrl>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
-    <ReleaseVersion>0.1.0</ReleaseVersion>
+    <ReleaseVersion>1.1</ReleaseVersion>
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.7.12" />
-    <PackageReference Include="NLog.Config" Version="4.6.6" />
+    <PackageReference Include="NLog.Config" Version="4.6.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/scrubfu/Scrubfu.csproj
+++ b/src/scrubfu/Scrubfu.csproj
@@ -5,7 +5,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PackageId>Scrubfu</PackageId>
-    <Version>0.1.0</Version>
+    <Version>1.1.0</Version>
     <Authors>Darin Morris, Paul van Coller</Authors>
     <Company>Grindrod Bank Limited</Company>
     <Description>Scrubfu is a data scrubbing &amp; obfuscation utility for PostgreSQL databases.</Description>
@@ -14,7 +14,7 @@
     <RepositoryType>Git</RepositoryType>
     <PackageProjectUrl>https://github.com/GrindrodBank/scrubfu</PackageProjectUrl>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
-    <ReleaseVersion>1.1</ReleaseVersion>
+    <ReleaseVersion>1.=1</ReleaseVersion>
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
   </PropertyGroup>
 

--- a/tests/Scrubfu.Tests/Scrubfu.Tests.csproj
+++ b/tests/Scrubfu.Tests/Scrubfu.Tests.csproj
@@ -1,19 +1,21 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
-    <ReleaseVersion>0.1.0</ReleaseVersion>
+    <ReleaseVersion>1.1</ReleaseVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.6.3">
+    <PackageReference Include="coverlet.msbuild" Version="2.8.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+<PrivateAssets>all</PrivateAssets>
+</PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR upgrades scrubfu to .Net Core 3.1, together with updating any dependencies to their latest versions.

Additionally, it also updates the DockerFile and CircleCI config to utilize the .Net Core 3.1 SDKs.